### PR TITLE
Fix build by removing external fonts

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -88,7 +88,7 @@ html {
 body {
   background: var(--background);
   color: var(--foreground);
-  font-family: var(--font-geist-sans), system-ui, sans-serif;
+  font-family: system-ui, sans-serif;
   line-height: 1.6;
   min-height: 100vh;
   transition: all 0.3s ease;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,18 +1,7 @@
 import type { Metadata, Viewport } from "next";
-import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import ErrorBoundary from "@/components/ErrorBoundary";
 import { ThemeProvider } from "@/contexts/ThemeContext";
-
-const geistSans = Geist({
-  variable: "--font-geist-sans",
-  subsets: ["latin"],
-});
-
-const geistMono = Geist_Mono({
-  variable: "--font-geist-mono",
-  subsets: ["latin"],
-});
 
 export const metadata: Metadata = {
   title: "AuraDex - Pokémon Database",
@@ -45,9 +34,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en">
-      <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
-      >
+      <body className="antialiased">
         <ThemeProvider>
           <ErrorBoundary>
             {children}


### PR DESCRIPTION
## Summary
- remove remote font imports to build offline
- set system font stack in globals

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68499407eb508325837d795f90d7e3cc