### PR TITLE
Fix generation dropdown overlap

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -143,18 +143,18 @@ body {
 /* Dropdown z-index fixes */
 .dropdown-container {
   position: relative;
-  z-index: 9999;
+  z-index: 50; /* ensure dropdowns appear above content */
 }
 
 .dropdown-backdrop {
   position: fixed;
   inset: 0;
-  z-index: 9998;
+  z-index: 40;
 }
 
 .dropdown-menu {
   position: absolute;
-  z-index: 9999;
+  z-index: 50;
 }
 
 /* Ensure dropdowns are not clipped by parent containers */


### PR DESCRIPTION
## Summary
- tweak z-index for dropdown menu, container, and backdrop so it's clickable

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684995704f888325a584f585892102e0