### PR TITLE
Improve theme and add API caching

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -33,6 +33,12 @@
   50% { box-shadow: 0 0 30px rgba(59, 130, 246, 0.6); }
 }
 
+@keyframes gradient-bg {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
+}
+
 .animate-in {
   animation: animate-in 0.5s ease-out;
 }
@@ -49,31 +55,36 @@
   animation: glow-pulse 2s ease-in-out infinite;
 }
 
+.animate-gradient {
+  background-size: 200% 200%;
+  animation: gradient-bg 15s ease infinite;
+}
+
 :root {
   /* Light theme */
-  --background: linear-gradient(135deg, #f8fafc 0%, #e2e8f0 100%);
+  --background: radial-gradient(circle at top left, #f0f9ff, #e0f2fe 40%, #fff1f2 100%);
   --foreground: #1e293b;
-  --card-background: rgba(255, 255, 255, 0.8);
+  --card-background: rgba(255, 255, 255, 0.85);
   --card-border: rgba(255, 255, 255, 0.2);
-  --primary: #3b82f6;
+  --primary: #6366f1;
   --primary-foreground: #ffffff;
   --secondary: #64748b;
   --muted: #f1f5f9;
-  --accent: #8b5cf6;
+  --accent: #ec4899;
   --destructive: #ef4444;
 }
 
 [data-theme="dark"] {
   /* Dark theme */
-  --background: linear-gradient(135deg, #0f172a 0%, #1e293b 50%, #334155 100%);
+  --background: radial-gradient(circle at top left, #0f172a, #1e293b 50%, #312e81 100%);
   --foreground: #f8fafc;
-  --card-background: rgba(15, 23, 42, 0.8);
+  --card-background: rgba(15, 23, 42, 0.85);
   --card-border: rgba(255, 255, 255, 0.1);
-  --primary: #60a5fa;
+  --primary: #8b5cf6;
   --primary-foreground: #1e293b;
   --secondary: #94a3b8;
   --muted: #1e293b;
-  --accent: #a78bfa;
+  --accent: #f472b6;
   --destructive: #f87171;
 }
 

--- a/src/components/PokemonDetail.tsx
+++ b/src/components/PokemonDetail.tsx
@@ -69,7 +69,7 @@ const PokemonDetail = ({ pokemonId }: PokemonDetailProps) => {
     return (
       <div className="min-h-screen">
         {/* Hero Background */}
-        <div className="fixed inset-0 bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 dark:from-gray-900 dark:via-blue-900/20 dark:to-purple-900/20" />
+        <div className="fixed inset-0 bg-gradient-to-r from-purple-100 via-indigo-100 to-blue-100 dark:from-gray-900 dark:via-purple-900/20 dark:to-blue-900/20 animate-gradient" />
         <div className="fixed inset-0 bg-[url('data:image/svg+xml,%3Csvg%20width%3D%2260%22%20height%3D%2260%22%20viewBox%3D%220%200%2060%2060%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20fill%3D%22%239C92AC%22%20fill-opacity%3D%220.1%22%3E%3Ccircle%20cx%3D%2230%22%20cy%3D%2230%22%20r%3D%222%22/%3E%3C/g%3E%3C/g%3E%3C/svg%3E')] opacity-40" />
         
         <div className="relative z-10 flex items-center justify-center min-h-screen">
@@ -85,7 +85,7 @@ const PokemonDetail = ({ pokemonId }: PokemonDetailProps) => {
     return (
       <div className="min-h-screen">
         {/* Hero Background */}
-        <div className="fixed inset-0 bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 dark:from-gray-900 dark:via-blue-900/20 dark:to-purple-900/20" />
+        <div className="fixed inset-0 bg-gradient-to-r from-purple-100 via-indigo-100 to-blue-100 dark:from-gray-900 dark:via-purple-900/20 dark:to-blue-900/20 animate-gradient" />
         <div className="fixed inset-0 bg-[url('data:image/svg+xml,%3Csvg%20width%3D%2260%22%20height%3D%2260%22%20viewBox%3D%220%200%2060%2060%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20fill%3D%22%239C92AC%22%20fill-opacity%3D%220.1%22%3E%3Ccircle%20cx%3D%2230%22%20cy%3D%2230%22%20r%3D%222%22/%3E%3C/g%3E%3C/g%3E%3C/svg%3E')] opacity-40" />
         
         <div className="relative z-10 flex items-center justify-center min-h-screen">
@@ -443,7 +443,7 @@ const PokemonDetail = ({ pokemonId }: PokemonDetailProps) => {
   return (
     <div className="min-h-screen">
       {/* Background */}
-      <div className="fixed inset-0 bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 dark:from-gray-900 dark:via-blue-900/20 dark:to-purple-900/20" />
+      <div className="fixed inset-0 bg-gradient-to-r from-purple-100 via-indigo-100 to-blue-100 dark:from-gray-900 dark:via-purple-900/20 dark:to-blue-900/20 animate-gradient" />
       <div className="fixed inset-0 bg-[url('data:image/svg+xml,%3Csvg%20width%3D%2260%22%20height%3D%2260%22%20viewBox%3D%220%200%2060%2060%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20fill%3D%22%239C92AC%22%20fill-opacity%3D%220.1%22%3E%3Ccircle%20cx%3D%2230%22%20cy%3D%2230%22%20r%3D%222%22/%3E%3C/g%3E%3C/g%3E%3C/svg%3E')] opacity-40" />
       
       <div className="relative z-10">

--- a/src/components/PokemonList.tsx
+++ b/src/components/PokemonList.tsx
@@ -229,7 +229,7 @@ const PokemonList = () => {
   return (
     <div className="min-h-screen">
       {/* Hero Background */}
-      <div className="fixed inset-0 bg-gradient-to-br from-blue-50 via-indigo-50 to-purple-50 dark:from-gray-900 dark:via-blue-900/20 dark:to-purple-900/20" />
+      <div className="fixed inset-0 bg-gradient-to-r from-purple-100 via-indigo-100 to-blue-100 dark:from-gray-900 dark:via-purple-900/20 dark:to-blue-900/20 animate-gradient" />
       <div className="fixed inset-0 bg-[url('data:image/svg+xml,%3Csvg%20width%3D%2260%22%20height%3D%2260%22%20viewBox%3D%220%200%2060%2060%22%20xmlns%3D%22http%3A//www.w3.org/2000/svg%22%3E%3Cg%20fill%3D%22none%22%20fill-rule%3D%22evenodd%22%3E%3Cg%20fill%3D%22%239C92AC%22%20fill-opacity%3D%220.1%22%3E%3Ccircle%20cx%3D%2230%22%20cy%3D%2230%22%20r%3D%222%22/%3E%3C/g%3E%3C/g%3E%3C/svg%3E')] opacity-40" />
       
       <div className="relative z-10">

--- a/src/utils/pokemon-api.ts
+++ b/src/utils/pokemon-api.ts
@@ -15,41 +15,85 @@ export const api = axios.create({
   timeout: 10000, // 10 second timeout
 });
 
+// Simple in-memory cache with localStorage persistence
+const cache = new Map<string, { data: unknown; timestamp: number }>();
+const CACHE_TTL = 1000 * 60 * 60; // 1 hour
+
+function getCache<T>(key: string): T | null {
+  const now = Date.now();
+  const memory = cache.get(key);
+  if (memory && now - memory.timestamp < CACHE_TTL) return memory.data as T;
+
+  if (typeof localStorage !== 'undefined') {
+    try {
+      const item = localStorage.getItem(key);
+      if (item) {
+        const parsed = JSON.parse(item) as { data: T; timestamp: number };
+        if (now - parsed.timestamp < CACHE_TTL) {
+          cache.set(key, parsed);
+          return parsed.data;
+        }
+      }
+    } catch {
+      /* ignore corrupt cache */
+    }
+  }
+  return null;
+}
+
+function setCache<T>(key: string, data: T) {
+  const value = { data, timestamp: Date.now() };
+  cache.set(key, value);
+  if (typeof localStorage !== 'undefined') {
+    try {
+      localStorage.setItem(key, JSON.stringify(value));
+    } catch {
+      /* ignore storage errors */
+    }
+  }
+}
+
+async function fetchWithCache<T>(path: string): Promise<T> {
+  const key = `poke:${path}`;
+  const cached = getCache<T>(key);
+  if (cached) return cached;
+
+  const response = await api.get<T>(path);
+  setCache(key, response.data);
+  return response.data;
+}
+
 export const pokemonApi = {
   // Get list of Pokemon
   getPokemonList: async (offset = 0, limit = 20): Promise<PokemonListResponse> => {
-    const response = await api.get(`/pokemon?offset=${offset}&limit=${limit}`);
-    return response.data;
+    return fetchWithCache<PokemonListResponse>(
+      `/pokemon?offset=${offset}&limit=${limit}`
+    );
   },
 
   // Get Pokemon by ID or name
   getPokemon: async (idOrName: string | number): Promise<Pokemon> => {
-    const response = await api.get(`/pokemon/${idOrName}`);
-    return response.data;
+    return fetchWithCache<Pokemon>(`/pokemon/${idOrName}`);
   },
 
   // Get Pokemon species data
   getPokemonSpecies: async (idOrName: string | number): Promise<PokemonSpecies> => {
-    const response = await api.get(`/pokemon-species/${idOrName}`);
-    return response.data;
+    return fetchWithCache<PokemonSpecies>(`/pokemon-species/${idOrName}`);
   },
 
   // Get evolution chain
   getEvolutionChain: async (id: number): Promise<EvolutionChain> => {
-    const response = await api.get(`/evolution-chain/${id}`);
-    return response.data;
+    return fetchWithCache<EvolutionChain>(`/evolution-chain/${id}`);
   },
 
   // Get type effectiveness
   getTypeEffectiveness: async (type: string): Promise<TypeEffectiveness> => {
-    const response = await api.get(`/type/${type}`);
-    return response.data;
+    return fetchWithCache<TypeEffectiveness>(`/type/${type}`);
   },
 
   // Get move data
   getMove: async (idOrName: string | number): Promise<Move> => {
-    const response = await api.get(`/move/${idOrName}`);
-    return response.data;
+    return fetchWithCache<Move>(`/move/${idOrName}`);
   },
 
   // Search Pokemon


### PR DESCRIPTION
## Summary
- implement client-side caching for PokéAPI requests
- update global theme variables with vibrant gradients
- add animated gradient backgrounds
- apply new background styles to pokemon pages

## Testing
- `npm run lint`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68499a96e52483259f0a5f9f7453b63b