### PR TITLE
Enable move detail modal

### DIFF
--- a/src/components/PokemonDetail/components/MovesTab.tsx
+++ b/src/components/PokemonDetail/components/MovesTab.tsx
@@ -6,9 +6,10 @@ import { VERSION_GROUPS, MOVE_CATEGORIES, TYPE_COLORS } from '@/constants/pokemo
 
 interface MovesTabProps {
   pokemon: Pokemon;
+  onMoveClick?: (moveName: string) => void;
 }
 
-export const MovesTab: React.FC<MovesTabProps> = ({ pokemon }) => {
+export const MovesTab: React.FC<MovesTabProps> = ({ pokemon, onMoveClick }) => {
   const [selectedVersionGroup, setSelectedVersionGroup] = useState<string>('');
   const [moveDetails, setMoveDetails] = useState<Record<string, Move | { loading: boolean }>>({});
 
@@ -126,21 +127,6 @@ export const MovesTab: React.FC<MovesTabProps> = ({ pokemon }) => {
     }
   };
 
-  // Function to open move details modal
-  const openMoveModal = async (moveName: string) => {
-    // If we don't have the move details yet, load them
-    if (!moveDetails[moveName] || 'loading' in moveDetails[moveName]) {
-      await loadMoveDetails(moveName);
-    }
-    
-    // For now, just console.log the move details
-    const moveDetail = moveDetails[moveName];
-    if (moveDetail && !('loading' in moveDetail)) {
-      console.log('Move details:', moveDetail);
-      // TODO: Implement modal functionality
-    }
-  };
-
   // Preload move details for visible moves using batch loading
   const preloadMoveDetails = async (moves: Array<{ move: { name: string; url: string }; level: number }>) => {
     const visibleMoves = moves.slice(0, 15); // Load first 15 moves
@@ -181,7 +167,7 @@ export const MovesTab: React.FC<MovesTabProps> = ({ pokemon }) => {
     return (
       <tr 
         className="border-b border-gray-100 dark:border-gray-800 hover:bg-white/50 dark:hover:bg-gray-800/50 transition-colors cursor-pointer"
-        onClick={() => openMoveModal(move.move.name)}
+        onClick={() => onMoveClick?.(move.move.name)}
         title="Click to view detailed move information"
       >
         {showLevel && (

--- a/src/components/PokemonDetail/index.tsx
+++ b/src/components/PokemonDetail/index.tsx
@@ -40,7 +40,8 @@ const PokemonDetail: React.FC<PokemonDetailProps> = ({ pokemonId }) => {
     selectedMove,
     showMoveModal,
     setSelectedMove,
-    setShowMoveModal
+    setShowMoveModal,
+    openMoveModal
   } = useMoveDetails();
 
   // Encounters management
@@ -205,7 +206,7 @@ const PokemonDetail: React.FC<PokemonDetailProps> = ({ pokemonId }) => {
           />
         );
       case 'moves':
-        return <MovesTab pokemon={pokemon} />;
+        return <MovesTab pokemon={pokemon} onMoveClick={openMoveModal} />;
       case 'locations':
         return (
           <LocationsTab


### PR DESCRIPTION
## Summary
- add callback prop to `MovesTab` for handling clicks
- use `openMoveModal` from `useMoveDetails` in Pokemon detail page

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_684b11f93a388325bf9b9be540c2ba3e